### PR TITLE
:sparkles: Allow to drag/drop (copy) columns and remove columns

### DIFF
--- a/dial/gui/widgets/layers_tree/layers_tree_model.py
+++ b/dial/gui/widgets/layers_tree/layers_tree_model.py
@@ -86,7 +86,7 @@ class LayersTreeModel(AbstractTreeModel):
             return Qt.ItemIsEnabled
 
         if isinstance(index.internalPointer(), LayerNode):
-            return super().flags(index) | Qt.ItemIsDragEnabled | Qt.ItemIsDropEnabled
+            return super().flags(index) | Qt.ItemIsDragEnabled
 
         return super().flags(index)
 


### PR DESCRIPTION
Right click on any row, and a context menu will be displayed allowing to remove any selected row

What does this implement/fix? Explain your changes.
---------------------------------------------------
* Implements the `removeRows` function on the model to allow removing layers.
* Adds a context menu with a "Remove row" menu by right clicking on a row from the view.

Does this close any currently open issues?
------------------------------------------
#8 